### PR TITLE
Adds feature to start the captain.launch from a specific state

### DIFF
--- a/mrobosub_planning/launch/captain.launch
+++ b/mrobosub_planning/launch/captain.launch
@@ -1,7 +1,9 @@
 <launch>
     <arg name="machine" default="standard" />
+    <arg name="module" default="common_states" />
+    <arg name="state" default="Start" />
     <node name="captain" pkg="mrobosub_planning" type="captain.py" 
-        output="screen" args="$(arg machine)">
+        output="screen" args="$(arg machine) $(arg module) $(arg state)">
         <param 
             textfile="$(find mrobosub_planning)/param/globals.yaml" 
             type="yaml"

--- a/mrobosub_planning/launch/captain.launch
+++ b/mrobosub_planning/launch/captain.launch
@@ -1,9 +1,8 @@
 <launch>
     <arg name="machine" default="standard" />
-    <arg name="module" default="common_states" />
-    <arg name="state" default="Start" />
+    <arg name="state" default="common_states.Start" />
     <node name="captain" pkg="mrobosub_planning" type="captain.py" 
-        output="screen" args="$(arg machine) $(arg module) $(arg state)">
+        output="screen" args="$(arg machine) $(arg state)">
         <param 
             textfile="$(find mrobosub_planning)/param/globals.yaml" 
             type="yaml"

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from typing import Dict, NamedTuple, Type
+from importlib import import_module
 from umrsm import StateMachine, State, TransitionMap
 import common_states
 import standard_run
@@ -35,11 +36,29 @@ transition_maps: Dict[str, TransitionMap] = {
 
 if __name__ == "__main__":
     rospy.init_node("captain")
+    
     machine_name = sys.argv[1]
+
+    # Read the module that the user passed in
+    module_file_name = sys.argv[2]
+
+    # Read the starting state that the user wants
+    state_name = sys.argv[3]
+
+    # Programmatically include the module that the user requests
+    module = import_module(module_file_name)
+
+    # Programmatically instantiate the desired starting state from that module
+    starting_state = getattr(module, state_name)
+
+    # NOTE: The implicit precondition is that the `starting_state` desired 
+    #       is in the TransitionMap of this current machine.
+
+    # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> module:=<module> state:=<state>`
     machine = StateMachine(
         machine_name,
         transition_maps[machine_name],
-        common_states.Start,
+        starting_state,
         common_states.Stop,
     )
     try:

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-from typing import Dict, NamedTuple, Optional, Type
+from typing import Dict, NamedTuple, Type
 from importlib import import_module
-import inspect
 from umrsm import StateMachine, State, TransitionMap
 import common_states
 import standard_run
-import re
 
 # import prequal_strafe
 import prequal_turn
@@ -47,41 +45,31 @@ def state_class_from_str(full_state: str, transitions: TransitionMap) -> Type[St
     Returns:
         The class object for the state or a ValueError if there is an error finding the state.
     """
-    # A NamedTuple is a class made inside of a State. 
-    # This helper function finds the state name from a NamedTuple in the transition map. E.g. NamedTuple(StartState.Complete) would return "StartState"
-    def named_tuple_to_state_str(named_tuple: Type[NamedTuple]) -> str:
-        return named_tuple.__qualname__.split('.')[0]
+    def outcome_to_state_str(outcome: Type[NamedTuple]) -> str:
+        return outcome.__qualname__.split('.')[0] # __qualname__ returns the full name, including all wrapping classes, of a class.
     
-    # Helper function to turn a NamedTuple into its wrapping State. E.g. NamedTuple(StartState.Complete) would return State(StartState)
-    def named_tuple_to_state(named_tuple: Type[NamedTuple]) -> Type[State]:
-        module = import_module(named_tuple.__module__)
-        return getattr(module, named_tuple_to_state_str(named_tuple))
+    def outcome_to_state(outcome: Type[NamedTuple]) -> Type[State]:
+        module = import_module(outcome.__module__)
+        return getattr(module, outcome_to_state_str(outcome))
     
-    # Ensure that the full_state passed in is either "module.state" or "state". Can have at most one '.'.
+    # full_state should be "module.state" or "state".
     if full_state.count('.') > 1:
         raise ValueError(f"{full_state} should have at most one '.'")
-        
-    # Return the state from the full_state that looks like "module.state" or "state".
-    state = full_state.split('.')[1] if '.' in full_state else full_state
+    state = full_state.split('.')[-1]
 
-    # The format of a transition map entry is NamedTuple: State.
-    # We need to find NamedTuples whose State matches the passed in state.
-    found_named_tuples = [named_tuple for named_tuple in transitions.keys() if named_tuple_to_state_str(named_tuple) == state]
+    # Find Outcomes whose State matches the passed in state.
+    found_outcomes = [outcome for outcome in transitions.keys() if outcome_to_state_str(outcome) == state]
 
-    # Turn each candidate NamedTuple into a set of their corresponding States.
-    unique_found_states = set([named_tuple_to_state(named_tuple) for named_tuple in found_named_tuples])
+    # Turn each candidate Outcome into a set of their corresponding States.
+    unique_found_states = set(outcome_to_state(outcome) for outcome in found_outcomes)
 
     # If module is included, filter by the module included.
     if '.' in full_state:
-        unique_found_states = set([state for state in unique_found_states if state.__module__ == full_state.split(".")[0]])
+        unique_found_states = set(state for state in unique_found_states if state.__module__ == full_state.split(".")[0])
 
-    # If the state cannot be found, error.
-    if len(unique_found_states) == 0:
-        raise ValueError(f"Your selected {state=} is not in {unique_found_states=}. Please enter a state in the transition map.")
-
-    # If multiple states have been found, error.
-    if len(unique_found_states) > 1:
-        raise ValueError(f"{unique_found_states=} has multiples and can't disambiguate which state to start. Include module or check transition map.")
+    # If 0 or multiple states are found, cannot disambiguate which state to use.
+    if len(unique_found_states) != 1:
+        raise ValueError(f'{full_state=} does not uniquely describe a state. {unique_found_states=}')
     
     found_state = unique_found_states.pop()
 
@@ -93,10 +81,6 @@ if __name__ == "__main__":
     
     # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> state:=<state|module.state>`
     machine_name = sys.argv[1]
-
-    # Read the state that the user passed in, which is either
-    #  1) `module.state`
-    #  2) `state`, and the module has to be inferred
     full_state = sys.argv[2]
 
     starting_state = state_class_from_str(full_state, transition_maps[machine_name])

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -5,6 +5,7 @@ import inspect
 from umrsm import StateMachine, State, TransitionMap
 import common_states
 import standard_run
+import re
 
 # import prequal_strafe
 import prequal_turn
@@ -44,50 +45,50 @@ def state_class_from_str(full_state: str, transitions: TransitionMap) -> Optiona
         transitions (TransitionMap): The transition map from the associated machine name. 
     
     Returns:
-        The class object for the state or `None` if no/multiple are found.
+        The class object for the state or a ValueError if there is an error finding the state.
     """
-    if '.' in full_state:
-        # Split the full state into the module.state_name
-        module = full_state.split('.')[0]
-        state = full_state.split('.')[1]
-
-        # We are given a module, search for all of the classes in the module
-        # Note that inspect.getmembers() returns a tuple that looks like (class string name, class object)
-        classes = set(inspect.getmembers(import_module(module), inspect.isclass))
-
-        # Search through all of the tuples by the class string name to 
-        # find associated class object
-        found_class_options = [tup[1] for tup in classes if tup[0] == state]
-
-        # If we find none or multiple, uhh, break
-        if len(found_class_options) != 1:
-            return None
-
-        found_class = found_class_options[0]
-        return found_class
-    else:
-        # Assuming that no module is entered in the terminal, we have to find which module the state is in
-        # set because we want this to be unique
-        module_names = set([cls.__module__ for cls in transitions])
-
-        # We need to get each class for all of the modules included in the transitions module
-        # Note that inspect.getmembers() returns a tuple that looks like (class string name, class object)
-        classes_in_modules = [inspect.getmembers(import_module(mod), inspect.isclass) for mod in module_names]
-
-        # The above list is a list of lists, flatten this into just a list
-        classes_in_transition_map = set([subclass for cls in classes_in_modules for subclass in cls])
-
-        # Search through all of the tuples by the class string name to 
-        # find associated class object
-        found_class_options = [tup[1] for tup in classes_in_transition_map if tup[0] == full_state]
+    # A NamedTuple is a class made inside of a State. 
+    # This helper function finds the state name from a NamedTuple in the transition map. E.g. NamedTuple(StartState.Complete) would return "StartState"
+    def named_tuple_to_state_str(named_tuple: Type[NamedTuple]) -> str:
+        return named_tuple.__qualname__.split('.')[0]
+    
+    # Helper function to turn a NamedTuple into its wrapping State. E.g. NamedTuple(StartState.Complete) would return State(StartState)
+    def named_tuple_to_state(named_tuple: Type[NamedTuple]) -> Type[State]:
+        module = import_module(named_tuple.__module__)
+        return getattr(module, named_tuple_to_state_str(named_tuple))
+    
+    # Ensure that the full_state passed in is either "module.state" or "state". Can have at most one '.'.
+    if full_state.count('.') > 1:
+        raise ValueError(f"{full_state} should have at most one '.'")
         
-        # If we find none or multiple, uhh, break
-        if len(found_class_options) != 1:
-            return None
-        
-        found_class = found_class_options[0]
-        return found_class
+    # Return the state from the full_state that looks like "module.state" or "state".
+    state = full_state.split('.')[1] if '.' in full_state else full_state
 
+    # The format of a transition map entry is NamedTuple: State.
+    # We need to find NamedTuples whose State matches the passed in state.
+    found_named_tuples = [named_tuple for named_tuple in transitions.keys() if named_tuple_to_state_str(named_tuple) == state]
+
+    # Turn each candidate NamedTuple into a set of their corresponding States.
+    unique_found_states = set([named_tuple_to_state(named_tuple) for named_tuple in found_named_tuples])
+
+    # If the state cannot be found, error.
+    if len(unique_found_states) == 0:
+        raise ValueError(f"Your selected {state=} is not in {unique_found_states=}. Please enter a state in the transition map.")
+
+    # If multiple states have been found, error.
+    if len(unique_found_states) > 1:
+        raise ValueError(f"{unique_found_states=} has multiples and can't disambiguate which state to start. Include module or check transition map.")
+    
+    found_state = unique_found_states.pop()
+
+    # If they provide a module, then confirm that this is the state that the user wants by ensuring the found state's module matches.
+    if full_state.count('.') == 1:
+        module, _ = full_state.split('.')
+        if str(found_state.__module__) != module:
+            raise ValueError(f"{found_state=} does not have the same module as the {module=} passed in. Ensure you are using the correct state from the transition map.")
+    
+    return found_state
+    
 
 if __name__ == "__main__":
     rospy.init_node("captain")
@@ -104,8 +105,7 @@ if __name__ == "__main__":
     print(starting_state)
 
     if starting_state is None:
-        print(f"Could not find {full_state} in the transition map.")
-        exit()
+        raise ValueError(f"Could not find {full_state} in the transition map")
 
     # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> state:=<state|module.state>`
     

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from typing import Dict, NamedTuple, Type
+from typing import Dict, NamedTuple, Optional, Type
 from importlib import import_module
 import inspect
 from umrsm import StateMachine, State, TransitionMap
@@ -35,7 +35,7 @@ transition_maps: Dict[str, TransitionMap] = {
 }
 
 
-def state_class_from_str(full_state: str, transitions: TransitionMap):
+def state_class_from_str(full_state: str, transitions: TransitionMap) -> Optional[Type[State]]:
     """
     Find the associated class object from a given state name.
 

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -36,7 +36,7 @@ transition_maps: Dict[str, TransitionMap] = {
 }
 
 
-def state_class_from_str(full_state: str, transitions: TransitionMap) -> Optional[Type[State]]:
+def state_class_from_str(full_state: str, transitions: TransitionMap) -> Type[State]:
     """
     Find the associated class object from a given state name.
 
@@ -71,6 +71,10 @@ def state_class_from_str(full_state: str, transitions: TransitionMap) -> Optiona
     # Turn each candidate NamedTuple into a set of their corresponding States.
     unique_found_states = set([named_tuple_to_state(named_tuple) for named_tuple in found_named_tuples])
 
+    # If module is included, filter by the module included.
+    if '.' in full_state:
+        unique_found_states = set([state for state in unique_found_states if state.__module__ == full_state.split(".")[0]])
+
     # If the state cannot be found, error.
     if len(unique_found_states) == 0:
         raise ValueError(f"Your selected {state=} is not in {unique_found_states=}. Please enter a state in the transition map.")
@@ -81,18 +85,13 @@ def state_class_from_str(full_state: str, transitions: TransitionMap) -> Optiona
     
     found_state = unique_found_states.pop()
 
-    # If they provide a module, then confirm that this is the state that the user wants by ensuring the found state's module matches.
-    if full_state.count('.') == 1:
-        module, _ = full_state.split('.')
-        if str(found_state.__module__) != module:
-            raise ValueError(f"{found_state=} does not have the same module as the {module=} passed in. Ensure you are using the correct state from the transition map.")
-    
     return found_state
     
 
 if __name__ == "__main__":
     rospy.init_node("captain")
     
+    # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> state:=<state|module.state>`
     machine_name = sys.argv[1]
 
     # Read the state that the user passed in, which is either
@@ -101,13 +100,6 @@ if __name__ == "__main__":
     full_state = sys.argv[2]
 
     starting_state = state_class_from_str(full_state, transition_maps[machine_name])
-
-    print(starting_state)
-
-    if starting_state is None:
-        raise ValueError(f"Could not find {full_state} in the transition map")
-
-    # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> state:=<state|module.state>`
     
     machine = StateMachine(
         machine_name,

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -46,33 +46,26 @@ def state_class_from_str(full_state: str, transitions: TransitionMap) -> Type[St
         The class object for the state or a ValueError if there is an error finding the state.
     """
     def outcome_to_state_str(outcome: Type[NamedTuple]) -> str:
-        return outcome.__qualname__.split('.')[0] # __qualname__ returns the full name, including all wrapping classes, of a class.
+        return outcome.__qualname__.split('.')[0]
     
     def outcome_to_state(outcome: Type[NamedTuple]) -> Type[State]:
         module = import_module(outcome.__module__)
         return getattr(module, outcome_to_state_str(outcome))
     
-    # full_state should be "module.state" or "state".
     if full_state.count('.') > 1:
         raise ValueError(f"{full_state} should have at most one '.'")
+
     state = full_state.split('.')[-1]
-
-    # Find Outcomes whose State matches the passed in state.
     found_outcomes = [outcome for outcome in transitions.keys() if outcome_to_state_str(outcome) == state]
-
-    # Turn each candidate Outcome into a set of their corresponding States.
     unique_found_states = set(outcome_to_state(outcome) for outcome in found_outcomes)
-
-    # If module is included, filter by the module included.
+    
     if '.' in full_state:
         unique_found_states = set(state for state in unique_found_states if state.__module__ == full_state.split(".")[0])
 
-    # If 0 or multiple states are found, cannot disambiguate which state to use.
     if len(unique_found_states) != 1:
         raise ValueError(f'{full_state=} does not uniquely describe a state. {unique_found_states=}')
     
     found_state = unique_found_states.pop()
-
     return found_state
     
 

--- a/mrobosub_planning/src/captain.py
+++ b/mrobosub_planning/src/captain.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from typing import Dict, NamedTuple, Type
 from importlib import import_module
+import inspect
 from umrsm import StateMachine, State, TransitionMap
 import common_states
 import standard_run
@@ -34,27 +35,80 @@ transition_maps: Dict[str, TransitionMap] = {
 }
 
 
+def state_class_from_str(full_state: str, transitions: TransitionMap):
+    """
+    Find the associated class object from a given state name.
+
+    Arguments:
+        full_state (str): The state passed into roslaunch. Could be in the format `state` or `module.state`.
+        transitions (TransitionMap): The transition map from the associated machine name. 
+    
+    Returns:
+        The class object for the state or `None` if no/multiple are found.
+    """
+    if '.' in full_state:
+        # Split the full state into the module.state_name
+        module = full_state.split('.')[0]
+        state = full_state.split('.')[1]
+
+        # We are given a module, search for all of the classes in the module
+        # Note that inspect.getmembers() returns a tuple that looks like (class string name, class object)
+        classes = set(inspect.getmembers(import_module(module), inspect.isclass))
+
+        # Search through all of the tuples by the class string name to 
+        # find associated class object
+        found_class_options = [tup[1] for tup in classes if tup[0] == state]
+
+        # If we find none or multiple, uhh, break
+        if len(found_class_options) != 1:
+            return None
+
+        found_class = found_class_options[0]
+        return found_class
+    else:
+        # Assuming that no module is entered in the terminal, we have to find which module the state is in
+        # set because we want this to be unique
+        module_names = set([cls.__module__ for cls in transitions])
+
+        # We need to get each class for all of the modules included in the transitions module
+        # Note that inspect.getmembers() returns a tuple that looks like (class string name, class object)
+        classes_in_modules = [inspect.getmembers(import_module(mod), inspect.isclass) for mod in module_names]
+
+        # The above list is a list of lists, flatten this into just a list
+        classes_in_transition_map = set([subclass for cls in classes_in_modules for subclass in cls])
+
+        # Search through all of the tuples by the class string name to 
+        # find associated class object
+        found_class_options = [tup[1] for tup in classes_in_transition_map if tup[0] == full_state]
+        
+        # If we find none or multiple, uhh, break
+        if len(found_class_options) != 1:
+            return None
+        
+        found_class = found_class_options[0]
+        return found_class
+
+
 if __name__ == "__main__":
     rospy.init_node("captain")
     
     machine_name = sys.argv[1]
 
-    # Read the module that the user passed in
-    module_file_name = sys.argv[2]
+    # Read the state that the user passed in, which is either
+    #  1) `module.state`
+    #  2) `state`, and the module has to be inferred
+    full_state = sys.argv[2]
 
-    # Read the starting state that the user wants
-    state_name = sys.argv[3]
+    starting_state = state_class_from_str(full_state, transition_maps[machine_name])
 
-    # Programmatically include the module that the user requests
-    module = import_module(module_file_name)
+    print(starting_state)
 
-    # Programmatically instantiate the desired starting state from that module
-    starting_state = getattr(module, state_name)
+    if starting_state is None:
+        print(f"Could not find {full_state} in the transition map.")
+        exit()
 
-    # NOTE: The implicit precondition is that the `starting_state` desired 
-    #       is in the TransitionMap of this current machine.
-
-    # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> module:=<module> state:=<state>`
+    # Syntax `roslaunch mrobosub_planning captain.launch machine:=<machine> state:=<state|module.state>`
+    
     machine = StateMachine(
         machine_name,
         transition_maps[machine_name],


### PR DESCRIPTION
Closes #16 

See: https://docs.python.org/3/library/importlib.html for questions about how importlib works -- it's pretty neat.

I had some issues starting states for buoy, but I think that was because the topic wasn't being published to, since this was run on my personal computer. 

It worked when I ran 
`roslaunch mrobosub_planning captain.launch` (the default), 
`roslaunch mrobosub_planning captain.launch machine:=prequal_turn` (the existing functionality), and 
`roslaunch mrobosub_planning captain.launch machine:=prequal_turn module:=prequal_front state:=AlignGate` (the new arbitrary state functionality).