### PR TITLE
State params

### DIFF
--- a/mrobosub_planning/src/bin_transitions.py
+++ b/mrobosub_planning/src/bin_transitions.py
@@ -4,7 +4,7 @@ from umrsm import TransitionMap
 
 
 transitions:TransitionMap = {
-    Start.Complete: Submerge,
+    Start.Complete: Submerge.with_params(target_heave=0.75),
 
     Submerge.Submerged: ApproachBinOpen,
     Submerge.TimedOut: ApproachBinOpen,

--- a/mrobosub_planning/src/standard_run.py
+++ b/mrobosub_planning/src/standard_run.py
@@ -9,7 +9,7 @@ from umrsm import TransitionMap
 
 
 transitions: TransitionMap = {
-    Start.Complete: Submerge,
+    Start.Complete: Submerge.with_params(target_heave=2.),
 
     Submerge.Submerged: AlignGate,
     Submerge.TimedOut: AlignGate,

--- a/mrobosub_planning/src/typecheck.py
+++ b/mrobosub_planning/src/typecheck.py
@@ -10,6 +10,9 @@ for map_name, map in transition_maps.items():
         if not state.is_valid_income_type(outcome):
             print(f'{state} is mapped to by invalid outcome {outcome} in transition map "{map_name}"')
             errors += 1
+        if state._num_unexpected_params != 0:
+            print(f'{state} contains {state._num_unexpected_params} unexpected parameters')
+            errors += state._num_unexpected_params
 
 if errors == 0:
     print("No errors found")

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -4,6 +4,7 @@ Python metaprogramming."""
 from __future__ import annotations
 from abc import abstractmethod
 from typing import (
+    Any,
     Dict,
     Optional,
     Type,
@@ -68,7 +69,7 @@ class State(metaclass=StateMeta):
         return True
 
     @classmethod
-    def with_params(cls, **kwargs) -> Type['State']:
+    def with_params(cls, **kwargs: Dict[str, Any]) -> Type['State']:
         overrides: dict = kwargs.get('_param_overrides', {}).copy()
         overrides.update(kwargs)
         kwargs['_param_overrides'] = overrides

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -77,7 +77,7 @@ class State(metaclass=StateMeta):
             if not hasattr(cls, k):
                 warnings.warn(f"overriding parameter {k}, which is not defined on {cls}", stacklevel=2)
                 num_unexpected += 1
-        overrides: dict = kwargs.get('_param_overrides', {}).copy()
+        overrides: dict = getattr(cls, '_param_overrides', {}).copy()
         overrides.update(kwargs)
         kwargs['_param_overrides'] = overrides
         kwargs['__module__'] = cls.__module__

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -33,7 +33,18 @@ class SoftStopTransition(NamedTuple):
     pass
 
 
-class State:
+class StateMeta(type):
+    def _rendered_repr(self) -> str:
+        if not hasattr(self, '_param_overrides'):
+            return f'state {self.__name__}'
+        param_overrides = getattr(self, '_param_overrides')
+        params_str = ', '.join(f'{k}={v}' for k, v in param_overrides.items())
+        return f'state {self.__qualname__} with {params_str}'
+
+    def __repr__(self) -> str:
+        return f'<{self._rendered_repr()}>'
+
+class State(metaclass=StateMeta):
     """States contain logic that will be executed by the StateMachine.
 
     Each State also contains class variables for each parameter on the parameter server, which
@@ -58,7 +69,15 @@ class State:
 
     @classmethod
     def with_params(cls, **kwargs) -> Type['State']:
+        overrides: dict = kwargs.get('_param_overrides', {}).copy()
+        overrides.update(kwargs)
+        kwargs['_param_overrides'] = overrides
+        kwargs['__module__'] = cls.__module__
         return type(cls.__name__, (cls,), kwargs)
+
+    @classmethod
+    def __repr__(cls) -> str:
+        return f'<instance of {cls._rendered_repr()}>'
 
 TransitionMap = Dict[Type[NamedTuple], Type[State]]
 

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -69,7 +69,7 @@ class State(metaclass=StateMeta):
         return True
 
     @classmethod
-    def with_params(cls, **kwargs: Dict[str, Any]) -> Type['State']:
+    def with_params(cls, **kwargs: Any) -> Type['State']:
         overrides: dict = kwargs.get('_param_overrides', {}).copy()
         overrides.update(kwargs)
         kwargs['_param_overrides'] = overrides

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -56,6 +56,9 @@ class State:
     def is_valid_income_type(cls, outcome_type: Type[NamedTuple]) -> bool:
         return True
 
+    @classmethod
+    def with_params(cls, **kwargs) -> Type['State']:
+        return type(cls.__name__, (cls,), kwargs)
 
 TransitionMap = Dict[Type[NamedTuple], Type[State]]
 

--- a/mrobosub_planning/src/umrsm.py
+++ b/mrobosub_planning/src/umrsm.py
@@ -10,6 +10,7 @@ from typing import (
     Type,
     Tuple,
 )
+import warnings
 import rospy
 from std_msgs.msg import String
 from std_srvs.srv import Trigger, TriggerRequest
@@ -52,6 +53,7 @@ class State(metaclass=StateMeta):
         can be accessed using self. Data that should be shared between calls of handle should be
         set as an instance variable.
     """
+    _num_unexpected_params = 0
 
     def __init__(self, prev_outcome: NamedTuple):
         self.prev_outcome = prev_outcome
@@ -70,10 +72,16 @@ class State(metaclass=StateMeta):
 
     @classmethod
     def with_params(cls, **kwargs: Any) -> Type['State']:
+        num_unexpected = 0
+        for k in kwargs:
+            if not hasattr(cls, k):
+                warnings.warn(f"overriding parameter {k}, which is not defined on {cls}", stacklevel=2)
+                num_unexpected += 1
         overrides: dict = kwargs.get('_param_overrides', {}).copy()
         overrides.update(kwargs)
         kwargs['_param_overrides'] = overrides
         kwargs['__module__'] = cls.__module__
+        kwargs['_num_unexpected_params'] = cls._num_unexpected_params + num_unexpected
         return type(cls.__name__, (cls,), kwargs)
 
     @classmethod


### PR DESCRIPTION
Allows using State.with_params(param=value) to create a new subclass of the state with overridden parameters. Allows each transition map to use their own versions of the states--most useful for states shared among many maps and for quick prototyping.

Warns and fails typecheck.py if an unexpected parameter is passed.

Addresses #14 