### PR TITLE
Added a State called MoveToXY

### DIFF
--- a/mrobosub_planning/src/common_states.py
+++ b/mrobosub_planning/src/common_states.py
@@ -69,10 +69,10 @@ class MoveToXY(TimedState):
                 self.timer = rospy.get_time()
                 error = self.kP * PIO.calculate_x_y_magnitude()
                 heave = min(error, self.max_heave) 
-                PIO.set_target_twist_surge(heave)
+                PIO.set_target_twist_heave(heave)
             
             if rospy.get_time() - self.timer >= self.settle_time:
-                PIO.set_target_twist_surge(0)
+                PIO.set_target_twist_heave(0)
                 return self.Reached()
 
         return None

--- a/mrobosub_planning/src/common_states.py
+++ b/mrobosub_planning/src/common_states.py
@@ -77,7 +77,7 @@ class MoveToXY(TimedState):
 
         return None
     
-    def handle_once_timedout(self) -> Optional[NamedTuple]:
+    def handle_once_timedout(self) -> NamedTuple:
         return self.TimedOut()
 
     target_x:             float = 0.0

--- a/mrobosub_planning/src/common_states.py
+++ b/mrobosub_planning/src/common_states.py
@@ -54,7 +54,7 @@ class MoveToXY(TimedState):
         PIO.set_target_pose_x(self.target_x)
         PIO.set_target_pose_y(self.target_y)
         
-        desired_angle = PIO.calculate_angle_to_global_position()
+        desired_angle = PIO.calculate_yaw_to_target()
         PIO.set_target_pose_yaw(desired_angle)
 
         if not PIO.is_yaw_within_threshold(self.yaw_threshold):
@@ -67,7 +67,7 @@ class MoveToXY(TimedState):
         if self._reached_angle:
             if not PIO.is_magnitude_within_threshold(self.magnitude_threshold):
                 self.timer = rospy.get_time()
-                error = self.kP * PIO.calculate_x_y_magnitude()
+                error = self.kP * PIO.calculate_distance_to_target()
                 heave = min(error, self.max_heave) 
                 PIO.set_target_twist_heave(heave)
             

--- a/mrobosub_planning/src/common_states.py
+++ b/mrobosub_planning/src/common_states.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 from umrsm import State, NamedTuple
 from abstract_states import TimedState
 from periodic_io import PIO
@@ -38,6 +38,59 @@ class Submerge(TimedState):
 
     def handle_once_timedout(self) -> TimedOut:
         return self.TimedOut()
+    
+class MoveToXY(TimedState):
+    class Reached(NamedTuple):
+        pass
+
+    class TimedOut(NamedTuple):
+        pass
+    
+    def __init__(self, prev_outcome: NamedTuple):
+        super().__init__(prev_outcome)
+        self.timer = rospy.get_time()
+    
+    def handle_if_not_timedout(self) -> Optional[NamedTuple]:
+        PIO.set_target_pose_x(self.target_x)
+        PIO.set_target_pose_y(self.target_y)
+        
+        desired_angle = PIO.calculate_angle_to_global_position()
+        PIO.set_target_pose_yaw(desired_angle)
+
+        if not PIO.is_yaw_within_threshold(self.yaw_threshold):
+            self.timer = rospy.get_time()
+
+        if not self._reached_angle and rospy.get_time() - self.timer >= self.settle_time:
+            self._reached_angle = True
+            self.timer = rospy.get_time()
+        
+        if self._reached_angle:
+            if not PIO.is_magnitude_within_threshold(self.magnitude_threshold):
+                self.timer = rospy.get_time()
+                error = self.kP * PIO.calculate_x_y_magnitude()
+                heave = min(error, self.max_heave) 
+                PIO.set_target_twist_surge(heave)
+            
+            if rospy.get_time() - self.timer >= self.settle_time:
+                PIO.set_target_twist_surge(0)
+                return self.Reached()
+
+        return None
+    
+    def handle_once_timedout(self) -> Optional[NamedTuple]:
+        return self.TimedOut()
+
+    target_x:             float = 0.0
+    target_y:             float = 0.0
+    magnitude_threshold:  float = 0.1
+    yaw_threshold:        float = 2.0
+    settle_time:          float = 1.0   # should we use a separate angle settle time and position settle time
+    timeout:              float = 20.0
+    
+    kP:                   float = 0.01  # this is the coefficient of the proportional term in PID
+    max_heave:            float = 0.3
+    
+    _reached_angle:       bool  = False
 
 
 class Stop(State):

--- a/mrobosub_planning/src/periodic_io.py
+++ b/mrobosub_planning/src/periodic_io.py
@@ -1,4 +1,4 @@
-from math import atan2, sqrt
+import math
 import rosgraph
 import rospy
 from std_msgs.msg import Float64, Bool, Int32
@@ -71,7 +71,7 @@ class PIO:
     
     @classmethod
     def is_magnitude_within_threshold(cls, threshold: float) -> float:
-        magnitude: float = cls.calculate_x_y_magnitude()
+        magnitude: float = cls.calculate_distance_to_target()
         return magnitude <= threshold
 
     @classmethod
@@ -79,22 +79,19 @@ class PIO:
         return abs(cls.TargetPose.heave - cls.Pose.heave) <= threshold
     
     @classmethod
-    def calculate_angle_to_global_position(cls) -> float:
-        # v1 = <x = /pose/x, y = /pose/y> is the current position 
-        # v2 = <target_x,    target_y> is the current position 
+    def calculate_yaw_to_target(cls) -> float:
         # the direction vector to the target d = v2 - v1
         # the angle to this would be arctan(dy / dx)
-        dx: float = cls.TargetPose.x - cls.Pose.x
-        dy: float = cls.TargetPose.y - cls.Pose.y
+        dx = cls.TargetPose.x - cls.Pose.x
+        dy = cls.TargetPose.y - cls.Pose.y
 
-        return atan2(dy, dx)
+        return math.atan2(dy, dx) * 180 / math.pi
     
     @classmethod
-    def calculate_x_y_magnitude(cls) -> float:
-        dx: float = cls.TargetPose.x - cls.Pose.x
-        dy: float = cls.TargetPose.y - cls.Pose.y
-        return sqrt(dx**2 + dy**2)
-
+    def calculate_distance_to_target(cls) -> float:
+        dx = cls.TargetPose.x - cls.Pose.x
+        dy = cls.TargetPose.y - cls.Pose.y
+        return math.sqrt(dx**2 + dy**2)
 
 
     # @classmethod

--- a/mrobosub_planning/src/periodic_io.py
+++ b/mrobosub_planning/src/periodic_io.py
@@ -1,3 +1,4 @@
+from math import atan2, sqrt
 import rosgraph
 import rospy
 from std_msgs.msg import Float64, Bool, Int32
@@ -28,11 +29,15 @@ class PIO:
         yaw = 0.0
         heave = 0.0
         roll = 0.0
+        x = 0.0
+        y = 0.0
 
     class TargetPose:
         yaw = 0.0
         heave = 0.0
         roll = 0.0
+        x = 0.0
+        y = 0.0
 
     buoy_collision = False
 
@@ -63,10 +68,34 @@ class PIO:
     @classmethod
     def is_yaw_within_threshold(cls, threshold: float) -> float:
         return abs(angle_error(cls.TargetPose.yaw, cls.Pose.yaw)) <= threshold
+    
+    @classmethod
+    def is_magnitude_within_threshold(cls, threshold: float) -> float:
+        magnitude: float = cls.calculate_x_y_magnitude()
+        return magnitude <= threshold
 
     @classmethod
     def is_heave_within_threshold(cls, threshold: float) -> float:
         return abs(cls.TargetPose.heave - cls.Pose.heave) <= threshold
+    
+    @classmethod
+    def calculate_angle_to_global_position(cls) -> float:
+        # v1 = <x = /pose/x, y = /pose/y> is the current position 
+        # v2 = <target_x,    target_y> is the current position 
+        # the direction vector to the target d = v2 - v1
+        # the angle to this would be arctan(dy / dx)
+        dx: float = cls.TargetPose.x - cls.Pose.x
+        dy: float = cls.TargetPose.y - cls.Pose.y
+
+        return atan2(dy, dx)
+    
+    @classmethod
+    def calculate_x_y_magnitude(cls) -> float:
+        dx: float = cls.TargetPose.x - cls.Pose.x
+        dy: float = cls.TargetPose.y - cls.Pose.y
+        return sqrt(dx**2 + dy**2)
+
+
 
     # @classmethod
     # def set_absolute_heading(cls, heading):
@@ -87,6 +116,16 @@ class PIO:
     def set_target_pose_roll(cls, target_roll: float) -> None:
         cls._target_pose_roll_pub.publish(target_roll)
         cls.TargetPose.roll = target_roll
+    
+    @classmethod
+    def set_target_pose_x(cls, target_x: float) -> None:
+        cls._target_pose_x_pub.publish(target_x)
+        cls.TargetPose.heave = target_x
+
+    @classmethod
+    def set_target_pose_y(cls, target_y: float) -> None:
+        cls._target_pose_y_pub.publish(target_y)
+        cls.TargetPose.y = target_y
 
     @classmethod
     def set_target_twist_roll(cls, override_roll: float) -> None:
@@ -243,6 +282,14 @@ class PIO:
             PIO.Pose.roll = msg.data
 
         @staticmethod
+        def x_callback(msg: Float64) -> None:
+            PIO.Pose.x = msg.data
+        
+        @staticmethod
+        def y_callback(msg: Float64) -> None:
+            PIO.Pose.y = msg.data
+       
+        @staticmethod
         def collision_callback(msg: Bool) -> None:
             PIO.buoy_collision = msg.data
 
@@ -250,12 +297,16 @@ class PIO:
     rospy.Subscriber("/pose/yaw", Float64, Callbacks.yaw_callback)
     rospy.Subscriber("/pose/heave", Float64, Callbacks.heave_callback)
     rospy.Subscriber("/pose/roll", Float64, Callbacks.roll_callback)
+    rospy.Subscriber("/pose/x", Float64, Callbacks.x_callback)
+    rospy.Subscriber("/pose/y", Float64, Callbacks.y_callback)
     rospy.Subscriber("/collision/collision", Bool, Callbacks.collision_callback)
 
     # Publishers
     _target_pose_heave_pub = rospy.Publisher("/target_pose/heave", Float64, queue_size=1)
     _target_pose_yaw_pub = rospy.Publisher("/target_pose/yaw", Float64, queue_size=1)
     _target_pose_roll_pub = rospy.Publisher("/target_pose/roll", Float64, queue_size=1)
+    _target_pose_x_pub = rospy.Publisher("/target_pose/x", Float64, queue_size=1)
+    _target_pose_y_pub = rospy.Publisher("/target_pose/y", Float64, queue_size=1)
 
     _target_twist_yaw_pub = rospy.Publisher("/target_twist/yaw", Float64, queue_size=1)
     _target_twist_roll_pub = rospy.Publisher("/target_twist/roll", Float64, queue_size=1)

--- a/mrobosub_planning/src/periodic_io.py
+++ b/mrobosub_planning/src/periodic_io.py
@@ -120,7 +120,7 @@ class PIO:
     @classmethod
     def set_target_pose_x(cls, target_x: float) -> None:
         cls._target_pose_x_pub.publish(target_x)
-        cls.TargetPose.heave = target_x
+        cls.TargetPose.x = target_x
 
     @classmethod
     def set_target_pose_y(cls, target_y: float) -> None:


### PR DESCRIPTION
Closes #24 

I tried to follow the format of `TurnToYaw` from `abstract_states.py`, but instead of stopping once the yaw is achieved, the robot surges forward at a speed proportional to the error between the current (x,y) and the target (x,y) until it settles at a threshold. Note that this code would be used in heavy conjunction with @RCoder01's meta state code to customize the target_x, target_y, etc.

I was looking into the PID node defined in `yaw_control.py` code and trying to think what the analogous code would be for this code, though I think heave control is good enough since this is a very rudimentary way of doing this.

Also, is `common_states.py` the file to put this in? I didn't see any other file that I liked for this.