### PR TITLE
Thruster mixing

### DIFF
--- a/mrobosub_bringup/launch/bringup.launch
+++ b/mrobosub_bringup/launch/bringup.launch
@@ -4,5 +4,6 @@
     <include file="$(find mrobosub_monitoring)/launch/monitoring.launch"/>
     <include file="$(find mrobosub_localization)/launch/localization.launch"/>
     <include file="$(find mrobosub_perception)/launch/perception.launch"/>
+    <include file="$(find mrobosub_fcu)/launch/fcu.launch"/>
     <node pkg="mrobosub_bringup" type="mavros" name="mavros" />
 </launch>

--- a/mrobosub_fcu/CMakeLists.txt
+++ b/mrobosub_fcu/CMakeLists.txt
@@ -7,7 +7,7 @@ project(mrobosub_fcu)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp mrobosub_msgs tf)
+find_package(catkin REQUIRED COMPONENTS mrobosub_msgs tf)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -100,7 +100,7 @@ find_package(catkin REQUIRED COMPONENTS roscpp mrobosub_msgs tf)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   LIBRARIES mrobosub_fcu
-  CATKIN_DEPENDS mrobosub_msgs roscpp tf
+  CATKIN_DEPENDS mrobosub_msgs tf
 #  DEPENDS system_lib
 )
 

--- a/mrobosub_fcu/launch/fcu.launch
+++ b/mrobosub_fcu/launch/fcu.launch
@@ -1,0 +1,3 @@
+<launch>
+  <include file="$(find mrobosub_fcu)/launch/thruster_mixing.launch"/>
+</launch>

--- a/mrobosub_fcu/launch/thruster_mixing.launch
+++ b/mrobosub_fcu/launch/thruster_mixing.launch
@@ -1,0 +1,3 @@
+<launch>
+    <node pkg="mrobosub_fcu" type="thruster_mixing.py" name="thruster_mixing" output="screen"/>
+</launch>

--- a/mrobosub_fcu/package.xml
+++ b/mrobosub_fcu/package.xml
@@ -5,42 +5,12 @@
   <description>
       flight controller unit, offerring direct control over motors and sensors
   </description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="michiganroboticsubmarine@gmail.com">Michigan Robotic Submarine</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>rospy</depend>
   <depend>tf</depend>
   <depend>mrobosub_msgs</depend>
-
 </package>

--- a/mrobosub_fcu/package.xml
+++ b/mrobosub_fcu/package.xml
@@ -18,18 +18,6 @@
   <license>BSD</license>
 
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/mrobosub_fcu</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
   <!-- The *depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
@@ -51,8 +39,7 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>roscpp</depend>
-  <depend>eigen</depend>
+  <depend>rospy</depend>
   <depend>tf</depend>
   <depend>mrobosub_msgs</depend>
 

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -1,0 +1,12 @@
+from tf.transformations import rotation_from_euler
+import numpy as np
+
+THRUSTER_YAW = [-45, 45, 45, -45, 0, 0, 0, 0]
+THRUSTER_PITCH = [0, 0, 0, 0, 90, 90, 90, 90]
+THRUSTER_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
+THRUSTER_SWAY = [26.67, -26.67, 26.67, -26.67, 26.67, -26.67, 26.67, -26.67]
+THRUSTER_TRANSLATIONS = np.array([THRUSTER_SURGE, THRUSTER_SWAY, [0.] * 8])
+
+THRUSTER_ROTATIONS = np.array([rotation_from_euler(yaw, pitch, 0.0, 'rzyx') for yaw, pitch in zip(THRUSTER_YAW, THRUSTER_PITCH)])
+THRUSTER_FORCE = THRUSTER_ROTATIONS @ np.array([1., 0., 0.])[:, None, None]
+THRUSTER_TORQUE = np.cross(THRUSTER_TRANSLATIONS, THRUSTER_FORCE)

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -10,23 +10,112 @@ from typing_extensions import Callable
 
 from mrobosub_lib.lib import Node
 from mrobosub_msgs.msg import MotorState
+from dataclasses import dataclass
 
-# degrees
-THRUSTERS_YAW = map(radians, [-45, 45, 45, -45, 0, 0, 0, 0])
-THRUSTERS_PITCH = map(radians, [0, 0, 0, 0, 90, 90, 90, 90])
-# meters
-THRUSTERS_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
-THRUSTERS_SWAY = [0.267, -0.267, 0.267, -0.267, 0.267, -0.267, 0.267, -0.267]
-THRUSTERS_TRANSLATION = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).T
-# newtons
-THRUSTER_MAX_FORCE = 1.0
+
+@dataclass
+class ThrusterDescriptor:
+    id: int
+    yaw: float  # degrees
+    pitch: float  # degrees
+    roll: float  # degrees
+    surge: float  # meters
+    sway: float  # meters
+    heave: float  # meters
+
+
+THRUSTER_MAX_FORCE = 1.0  # newtons
+CORNER_THRUSTER_SURGE = 0.2921
+CENTER_THRUSTER_SURGE = 0.127
+THRUSTER_SWAY = 0.267
+THRUSTERS = [
+    ThrusterDescriptor(
+        id=0,
+        yaw=-45,
+        pitch=0,
+        roll=0,
+        surge=CORNER_THRUSTER_SURGE,
+        sway=THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=1,
+        yaw=45,
+        pitch=0,
+        roll=0,
+        surge=CORNER_THRUSTER_SURGE,
+        sway=-THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=2,
+        yaw=45,
+        pitch=0,
+        roll=0,
+        surge=-CORNER_THRUSTER_SURGE,
+        sway=THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=3,
+        yaw=-45,
+        pitch=0,
+        roll=0,
+        surge=-CORNER_THRUSTER_SURGE,
+        sway=-THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=4,
+        yaw=0,
+        pitch=90,
+        roll=0,
+        surge=CENTER_THRUSTER_SURGE,
+        sway=THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=5,
+        yaw=0,
+        pitch=90,
+        roll=0,
+        surge=CENTER_THRUSTER_SURGE,
+        sway=-THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=6,
+        yaw=0,
+        pitch=90,
+        roll=0,
+        surge=-CENTER_THRUSTER_SURGE,
+        sway=THRUSTER_SWAY,
+        heave=0,
+    ),
+    ThrusterDescriptor(
+        id=7,
+        yaw=0,
+        pitch=90,
+        roll=0,
+        surge=-CENTER_THRUSTER_SURGE,
+        sway=-THRUSTER_SWAY,
+        heave=0,
+    ),
+]
+THRUSTERS.sort(key=lambda thruster: thruster.id)
 
 SUB_FRAME = np.diag([1, -1, -1])
 THRUSTERS_ROTATIONS = np.array(
     [
-        euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3] @ SUB_FRAME
-        for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)
+        euler_matrix(radians(thruster.yaw), radians(thruster.pitch), 0.0, "rzyx")[
+            :3, :3
+        ]
+        @ SUB_FRAME
+        for thruster in THRUSTERS
     ]
+)
+THRUSTERS_TRANSLATION = np.array(
+    [[thruster.surge, thruster.sway, thruster.heave] for thruster in THRUSTERS]
 )
 
 THRUSTERS_FORCE = (
@@ -38,6 +127,7 @@ INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX).T
 
 np.set_printoptions(suppress=True, precision=3)
 print(f"{THRUSTERS_ROTATIONS=}")
+print(f"{THRUSTERS_TRANSLATION=}")
 print(f"{THRUSTERS_FORCE=}")
 print(f"{THRUSTERS_TORQUE=}")
 print(f"{INV_TAM=}")
@@ -93,7 +183,9 @@ class ThrusterMixing(Node):
         if max_demand > THRUSTER_MAX_FORCE:
             forces /= max_demand
         scaled = THRUSTER_ALLOCATION_MATRIX.T @ forces
-        scale = np.nan_to_num(np.mean(scaled[wrench != 0] / wrench[wrench != 0]), nan=1.)
+        scale = np.nan_to_num(
+            np.mean(scaled[wrench != 0] / wrench[wrench != 0]), nan=1.0
+        )
         self.scale_pub.publish(scale)
 
         state = MotorState()

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -1,11 +1,15 @@
+#!/usr/bin/env python
+
 from tf.transformations import euler_matrix
 import numpy as np
 from math import radians
 import rospy
 from std_msgs.msg import Float64
+from typing import Any
 from typing_extensions import Callable
 
 from mrobosub_lib.lib import Node
+from mrobosub_msgs.msg import MotorState
 
 # degrees
 THRUSTERS_YAW = map(radians, [-45, 45, 45, -45, 0, 0, 0, 0])
@@ -17,60 +21,68 @@ THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).
 # newtons
 THRUSTER_MAX_FORCE = 1.0
 
-THRUSTERS_ROTATIONS = np.array(
-    euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3]
+SUB_FRAME = np.diag([1, -1, -1])
+THRUSTERS_ROTATIONS = np.array([
+    euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3] @ SUB_FRAME
     for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)
-)
+])
+
 THRUSTERS_FORCE = (
     THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0.0, 0.0])[None, :, None]
 ).squeeze()
 THRUSTERS_TORQUE = np.cross(THRUSTERS_TRANSLATIONS, THRUSTERS_FORCE)
-THRUSTER_ALLOCATION_MATRIX = np.hstack((TTHRUSTERS_FORCE, THRUSTERS_TORQUE))
-INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX)
+THRUSTER_ALLOCATION_MATRIX = np.hstack((THRUSTERS_FORCE, THRUSTERS_TORQUE))
+INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX).T
 
 np.set_printoptions(suppress=True, precision=3)
 print(f"{THRUSTERS_ROTATIONS=}")
 print(f"{THRUSTERS_FORCE=}")
 print(f"{THRUSTERS_TORQUE=}")
 print(f"{INV_TAM=}")
+print(f"{INV_TAM.shape=}")
+
 # this order must match with the order of dofs in TAM
-DOFS = "surge", "sway", "heave", "yaw", "pitch", "roll"
-NUM_MOTORS = INV_TAM.shape[1]
+DOFS = "surge", "sway", "heave", "roll", "pitch", "yaw"
+NUM_MOTORS = INV_TAM.shape[0]
 
 RATE = 100  # hz
 
 
 class ThrusterMixing(Node):
     def __init__(self) -> None:
+        super().__init__('thruster_mixing')
+        self.wrench = {dof: 0 for dof in DOFS}
         self.wrench_subs = {
             dof: rospy.Subscriber(
                 f"/output_wrench/{dof}", Float64, self.make_wrench_callback(dof)
             )
             for dof in DOFS
         }
-        self.wrench = {dof: 0 for dof in DOFS}
         self.motor_pubs = [
             rospy.Publisher(f"/motor_output/{i}", Float64, queue_size=1)
             for i in range(NUM_MOTORS)
         ]
+        self.all_motor_pub = rospy.Publisher('/motor_output', MotorState, queue_size=1)
 
     def run(self):
         self.timer = rospy.Timer(rospy.Duration.from_sec(1.0 / RATE), self.update)
         rospy.spin()
 
-    def make_wrench_callback(self, dof: str) -> Callable[[Float64]]:
+    def make_wrench_callback(self, dof: str) -> Callable[[Float64], None]:
         # direction dofs are in newtons, angle dofs are in newton-meters
         def callback(msg: Float64):
-            self.wrench[dof] = msg.value
+            self.wrench[dof] = msg.data
 
         return callback
 
-    def update(self):
-        wrench = np.array(self.wrench.values())
+    def update(self, _timer_event: Any):
+        wrench = np.array(list(self.wrench.values()))
         output = INV_TAM @ wrench
+        state = MotorState()
         for i, value in enumerate(output):
             self.motor_pubs[i].publish(value)
-
+            setattr(state, f"motor{i}", value)
+        self.all_motor_pub.publish(state)
 
 if __name__ == "__main__":
     ThrusterMixing().run()

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -17,7 +17,7 @@ THRUSTERS_PITCH = map(radians, [0, 0, 0, 0, 90, 90, 90, 90])
 # meters
 THRUSTERS_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
 THRUSTERS_SWAY = [0.267, -0.267, 0.267, -0.267, 0.267, -0.267, 0.267, -0.267]
-THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).T
+THRUSTERS_TRANSLATION = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).T
 # newtons
 THRUSTER_MAX_FORCE = 1.0
 
@@ -32,7 +32,7 @@ THRUSTERS_ROTATIONS = np.array(
 THRUSTERS_FORCE = (
     THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0.0, 0.0])[None, :, None]
 ).squeeze()
-THRUSTERS_TORQUE = np.cross(THRUSTERS_TRANSLATIONS, THRUSTERS_FORCE)
+THRUSTERS_TORQUE = np.cross(THRUSTERS_TRANSLATION, THRUSTERS_FORCE)
 THRUSTER_ALLOCATION_MATRIX = np.hstack((THRUSTERS_FORCE, THRUSTERS_TORQUE))
 INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX).T
 
@@ -82,7 +82,8 @@ class ThrusterMixing(Node):
         """Returns required motor output power for a certain demanded torque"""
         # This should probably be nonlinear according to the datasheet or experimental data
         # https://bluerobotics.com/store/thrusters/t100-t200-thrusters/t200-thruster-r2-rp/
-        return demanded_force / THRUSTER_MAX_FORCE
+        raw_demand = demanded_force / THRUSTER_MAX_FORCE
+        return np.clip(raw_demand, -1.0, 1.0)
 
     def update(self, _timer_event: Any):
         wrench = np.array(list(self.wrench.values()))

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -80,7 +80,8 @@ class ThrusterMixing(Node):
 
     def motor_force_curve(self, demanded_force: float) -> float:
         """Returns required motor output power for a certain demanded torque"""
-        # This should probably be nonlinear somehow?
+        # This should probably be nonlinear according to the datasheet or experimental data
+        # https://bluerobotics.com/store/thrusters/t100-t200-thrusters/t200-thruster-r2-rp/
         return demanded_force / THRUSTER_MAX_FORCE
 
     def update(self, _timer_event: Any):

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -1,12 +1,22 @@
-from tf.transformations import rotation_from_euler
+from tf.transformations import euler_matrix
 import numpy as np
+from math import radians
 
-THRUSTER_YAW = [-45, 45, 45, -45, 0, 0, 0, 0]
-THRUSTER_PITCH = [0, 0, 0, 0, 90, 90, 90, 90]
-THRUSTER_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
-THRUSTER_SWAY = [26.67, -26.67, 26.67, -26.67, 26.67, -26.67, 26.67, -26.67]
-THRUSTER_TRANSLATIONS = np.array([THRUSTER_SURGE, THRUSTER_SWAY, [0.] * 8])
+THRUSTERS_YAW = map(radians, [-45, 45, 45, -45, 0, 0, 0, 0])
+THRUSTERS_PITCH = map(radians, [0, 0, 0, 0, 90, 90, 90, 90])
+THRUSTERS_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
+THRUSTERS_SWAY = [0.2667, -0.2667, 0.2667, -0.2667, 0.2667, -0.2667, 0.2667, -0.2667]
+THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.] * 8]).T
+THRUSTER_MAX_FORCE = 0.25
 
-THRUSTER_ROTATIONS = np.array([rotation_from_euler(yaw, pitch, 0.0, 'rzyx') for yaw, pitch in zip(THRUSTER_YAW, THRUSTER_PITCH)])
-THRUSTER_FORCE = THRUSTER_ROTATIONS @ np.array([1., 0., 0.])[:, None, None]
-THRUSTER_TORQUE = np.cross(THRUSTER_TRANSLATIONS, THRUSTER_FORCE)
+THRUSTERS_ROTATIONS = np.array([euler_matrix(yaw, pitch, 0.0, 'rzyx')[:3, :3] for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)])
+THRUSTERS_FORCE = (THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0., 0.])[None, :, None]).squeeze()
+THRUSTERS_TORQUE = np.cross(THRUSTERS_TRANSLATIONS, THRUSTERS_FORCE)
+THRUSTER_ALLOCATION_MATRIX = np.hstack((THRUSTERS_FORCE, THRUSTERS_TORQUE))
+INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX)
+
+np.set_printoptions(suppress=True, precision=3)
+print(f'{THRUSTERS_ROTATIONS=}')
+print(f'{THRUSTERS_FORCE=}')
+print(f'{THRUSTERS_TORQUE=}')
+print(f'{INV_TAM=}')

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -89,10 +89,10 @@ class ThrusterMixing(Node):
         forces = INV_TAM @ wrench
 
         max_demand = np.max(forces)
-        scale = 1.0
         if max_demand > THRUSTER_MAX_FORCE:
-            scale = 1.0 / max_demand
-        forces *= scale
+            forces /= max_demand
+        scaled = THRUSTER_ALLOCATION_MATRIX.T @ forces
+        scale = np.nan_to_num(np.mean(scaled[wrench != 0] / wrench[wrench != 0]), nan=1.)
         self.scale_pub.publish(scale)
 
         state = MotorState()

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -1,22 +1,76 @@
 from tf.transformations import euler_matrix
 import numpy as np
 from math import radians
+import rospy
+from std_msgs.msg import Float64
+from typing_extensions import Callable
 
+from mrobosub_lib.lib import Node
+
+# degrees
 THRUSTERS_YAW = map(radians, [-45, 45, 45, -45, 0, 0, 0, 0])
 THRUSTERS_PITCH = map(radians, [0, 0, 0, 0, 90, 90, 90, 90])
+# meters
 THRUSTERS_SURGE = [0.2921, 0.2921, -0.2921, -0.2921, 0.127, 0.127, -0.127, -0.127]
-THRUSTERS_SWAY = [0.2667, -0.2667, 0.2667, -0.2667, 0.2667, -0.2667, 0.2667, -0.2667]
-THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.] * 8]).T
-THRUSTER_MAX_FORCE = 0.25
+THRUSTERS_SWAY = [0.267, -0.267, 0.267, -0.267, 0.267, -0.267, 0.267, -0.267]
+THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).T
+# newtons
+THRUSTER_MAX_FORCE = 1.0
 
-THRUSTERS_ROTATIONS = np.array([euler_matrix(yaw, pitch, 0.0, 'rzyx')[:3, :3] for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)])
-THRUSTERS_FORCE = (THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0., 0.])[None, :, None]).squeeze()
+THRUSTERS_ROTATIONS = np.array(
+    euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3]
+    for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)
+)
+THRUSTERS_FORCE = (
+    THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0.0, 0.0])[None, :, None]
+).squeeze()
 THRUSTERS_TORQUE = np.cross(THRUSTERS_TRANSLATIONS, THRUSTERS_FORCE)
-THRUSTER_ALLOCATION_MATRIX = np.hstack((THRUSTERS_FORCE, THRUSTERS_TORQUE))
+THRUSTER_ALLOCATION_MATRIX = np.hstack((TTHRUSTERS_FORCE, THRUSTERS_TORQUE))
 INV_TAM = np.linalg.pinv(THRUSTER_ALLOCATION_MATRIX)
 
 np.set_printoptions(suppress=True, precision=3)
-print(f'{THRUSTERS_ROTATIONS=}')
-print(f'{THRUSTERS_FORCE=}')
-print(f'{THRUSTERS_TORQUE=}')
-print(f'{INV_TAM=}')
+print(f"{THRUSTERS_ROTATIONS=}")
+print(f"{THRUSTERS_FORCE=}")
+print(f"{THRUSTERS_TORQUE=}")
+print(f"{INV_TAM=}")
+# this order must match with the order of dofs in TAM
+DOFS = "surge", "sway", "heave", "yaw", "pitch", "roll"
+NUM_MOTORS = INV_TAM.shape[1]
+
+RATE = 100  # hz
+
+
+class ThrusterMixing(Node):
+    def __init__(self) -> None:
+        self.wrench_subs = {
+            dof: rospy.Subscriber(
+                f"/output_wrench/{dof}", Float64, self.make_wrench_callback(dof)
+            )
+            for dof in DOFS
+        }
+        self.wrench = {dof: 0 for dof in DOFS}
+        self.motor_pubs = [
+            rospy.Publisher(f"/motor_output/{i}", Float64, queue_size=1)
+            for i in range(NUM_MOTORS)
+        ]
+
+    def run(self):
+        self.timer = rospy.Timer(rospy.Duration.from_sec(1.0 / RATE), self.update)
+        rospy.spin()
+
+    def make_wrench_callback(self, dof: str) -> Callable[[Float64]]:
+        # direction dofs are in newtons, angle dofs are in newton-meters
+        def callback(msg: Float64):
+            self.wrench[dof] = msg.value
+
+        return callback
+
+    def update(self):
+        wrench = np.array(self.wrench.values())
+        output = INV_TAM @ wrench
+        for i, value in enumerate(output):
+            self.motor_pubs[i].publish(value)
+
+
+if __name__ == "__main__":
+    ThrusterMixing().run()

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -150,11 +150,7 @@ class ThrusterMixing(Node):
             )
             for dof in DOFS
         }
-        self.motor_pubs = [
-            rospy.Publisher(f"/motor_output/{i}", Float64, queue_size=1)
-            for i in range(NUM_MOTORS)
-        ]
-        self.all_motor_pub = rospy.Publisher("/motor_output", MotorState, queue_size=1)
+        self.motor_pub = rospy.Publisher("/motor_output", MotorState, queue_size=1)
         self.scale_pub = rospy.Publisher("/motor_output/scale", Float64, queue_size=1)
 
     def run(self):
@@ -191,9 +187,8 @@ class ThrusterMixing(Node):
         state = MotorState()
         for i, force in enumerate(forces):
             output = self.motor_force_curve(force)
-            self.motor_pubs[i].publish(output)
             setattr(state, f"motor{i}", output)
-        self.all_motor_pub.publish(state)
+        self.motor_pub.publish(state)
 
 
 if __name__ == "__main__":

--- a/mrobosub_fcu/src/thruster_mixing.py
+++ b/mrobosub_fcu/src/thruster_mixing.py
@@ -22,10 +22,12 @@ THRUSTERS_TRANSLATIONS = np.array([THRUSTERS_SURGE, THRUSTERS_SWAY, [0.0] * 8]).
 THRUSTER_MAX_FORCE = 1.0
 
 SUB_FRAME = np.diag([1, -1, -1])
-THRUSTERS_ROTATIONS = np.array([
-    euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3] @ SUB_FRAME
-    for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)
-])
+THRUSTERS_ROTATIONS = np.array(
+    [
+        euler_matrix(yaw, pitch, 0.0, "rzyx")[:3, :3] @ SUB_FRAME
+        for yaw, pitch in zip(THRUSTERS_YAW, THRUSTERS_PITCH)
+    ]
+)
 
 THRUSTERS_FORCE = (
     THRUSTERS_ROTATIONS @ np.array([THRUSTER_MAX_FORCE, 0.0, 0.0])[None, :, None]
@@ -50,7 +52,7 @@ RATE = 100  # hz
 
 class ThrusterMixing(Node):
     def __init__(self) -> None:
-        super().__init__('thruster_mixing')
+        super().__init__("thruster_mixing")
         self.wrench = {dof: 0 for dof in DOFS}
         self.wrench_subs = {
             dof: rospy.Subscriber(
@@ -62,7 +64,8 @@ class ThrusterMixing(Node):
             rospy.Publisher(f"/motor_output/{i}", Float64, queue_size=1)
             for i in range(NUM_MOTORS)
         ]
-        self.all_motor_pub = rospy.Publisher('/motor_output', MotorState, queue_size=1)
+        self.all_motor_pub = rospy.Publisher("/motor_output", MotorState, queue_size=1)
+        self.scale_pub = rospy.Publisher("/motor_output/scale", Float64, queue_size=1)
 
     def run(self):
         self.timer = rospy.Timer(rospy.Duration.from_sec(1.0 / RATE), self.update)
@@ -75,14 +78,29 @@ class ThrusterMixing(Node):
 
         return callback
 
+    def motor_force_curve(self, demanded_force: float) -> float:
+        """Returns required motor output power for a certain demanded torque"""
+        # This should probably be nonlinear somehow?
+        return demanded_force / THRUSTER_MAX_FORCE
+
     def update(self, _timer_event: Any):
         wrench = np.array(list(self.wrench.values()))
-        output = INV_TAM @ wrench
+        forces = INV_TAM @ wrench
+
+        max_demand = np.max(forces)
+        scale = 1.0
+        if max_demand > THRUSTER_MAX_FORCE:
+            scale = 1.0 / max_demand
+        forces *= scale
+        self.scale_pub.publish(scale)
+
         state = MotorState()
-        for i, value in enumerate(output):
-            self.motor_pubs[i].publish(value)
-            setattr(state, f"motor{i}", value)
+        for i, force in enumerate(forces):
+            output = self.motor_force_curve(force)
+            self.motor_pubs[i].publish(output)
+            setattr(state, f"motor{i}", output)
         self.all_motor_pub.publish(state)
+
 
 if __name__ == "__main__":
     ThrusterMixing().run()

--- a/mrobosub_msgs/CMakeLists.txt
+++ b/mrobosub_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_message_files(
     HeadingRequest.msg
     Dvl.msg
     Imu.msg
+    MotorState.msg
 )
 
 add_service_files(

--- a/mrobosub_msgs/msg/MotorState.msg
+++ b/mrobosub_msgs/msg/MotorState.msg
@@ -1,0 +1,9 @@
+float32 motor0
+float32 motor1
+float32 motor2
+float32 motor3
+float32 motor4
+float32 motor5
+float32 motor6
+float32 motor7
+


### PR DESCRIPTION
Converts output wrenches (newtons or newton-meters) into motor output percentages (-1.0 to +1.0). If the requested wrenches exceed the limits of what the motor can produce, it scales all  requested wrenches down evenly (so hopefully the sub is just slower but the dynamics are similar). The scale is published to /motor_output/scale.
We can modify `THRUSTER_MAX_FORCE` and `motor_force_curve` if we want to output-limit the motors (ie. ensure they never go above 40% power to prevent current overdraw).

Should this node rotate the surge/sway/heave axes according to the sub's rotation or is that the responsibility of some other node? Is that even desired behavior?

Closes #46