### PR TITLE
Fix thruster board "busy"/"error"/"device not found"

### DIFF
--- a/mrobosub_hal/src/thruster_controller.py
+++ b/mrobosub_hal/src/thruster_controller.py
@@ -40,7 +40,7 @@ class ThrusterController(Node):
 
     def connect(self) -> bool:
         try:
-            self.serial = Serial(self.port)
+            self.serial = Serial(self.port, timeout=0.5, write_timeout=0.5)
         except SerialException as e:
             print("Could not connect to mini maestro", e)
             return False


### PR DESCRIPTION
added read and write timeout