### PR TITLE
Add modular states

### DIFF
--- a/mrobosub_planning/mrobosub_planning/common_states.py
+++ b/mrobosub_planning/mrobosub_planning/common_states.py
@@ -1,6 +1,5 @@
 from typing import Optional, Union
 
-from fpdf import Align
 from mrobosub_planning.umrsm import State, Outcome
 from mrobosub_planning.abstract_states import TimedState
 import rclpy
@@ -61,26 +60,6 @@ class AlignToYaw(TimedState):
     def handle_once_timedout(self) -> TimedOut:
         return self.TimedOut()
 
-class AlignToYaw(TimedState):
-    target_yaw = 0.0
-    yaw_threshold = 2.0
-
-    class Aligned(Outcome):
-        pass
-
-    class TimedOut(Outcome):
-        pass
-
-    def handle_if_not_timedout(self) -> Union[Aligned, None]:
-        self.io_node.set_target_pose_yaw(self.target_yaw)
-
-        if self.io_node.is_yaw_within_threshold(self.yaw_threshold):
-            return self.Aligned()
-        return None
-
-    def handle_once_timedout(self) -> TimedOut:
-        return self.TimedOut()
-
 class Surge(TimedState):
     class Surged(Outcome):
         pass
@@ -94,14 +73,12 @@ class Surge(TimedState):
 
     def handle_if_not_timedout(self) -> Union[Surged, None]:
         self.timeout = self.distance/self.velocity
-        self.io_node.set_target_twist_surge(self.velocity);
+        self.io_node.set_target_twist_surge(self.velocity)
 
-        #if self.io_node.calculate_distance_to_target():
-        #    return self.Submerged()
         return None
 
     def handle_once_timedout(self) -> Surged:
-        return self.Surged();
+        return self.Surged()
 
 
 class Stop(State):
@@ -121,26 +98,3 @@ class Stop(State):
 
 
 Surface = Stop
-
-class Surge(TimedState):
-    class Surged(Outcome):
-        pass
-
-    class TimedOut(Outcome):
-        pass
-    distance = 10
-    velocity = 2
-    timeout: float = distance/velocity
-
-
-    def handle_if_not_timedout(self) -> Union[Surged, None]:
-        self.timeout = self.distance/self.velocity
-        self.io_node.set_target_twist_surge(self.velocity);
-
-        #if self.io_node.calculate_distance_to_target():
-        #    return self.Submerged()
-        return None
-
-    def handle_once_timedout(self) -> Surged:
-        return self.Surged();
-     

--- a/mrobosub_planning/mrobosub_planning/common_states.py
+++ b/mrobosub_planning/mrobosub_planning/common_states.py
@@ -1,4 +1,6 @@
 from typing import Optional, Union
+
+from fpdf import Align
 from mrobosub_planning.umrsm import State, Outcome
 from mrobosub_planning.abstract_states import TimedState
 import rclpy
@@ -33,6 +35,27 @@ class Submerge(TimedState):
             self.heave_threshold
         ) and self.io_node.is_yaw_within_threshold(self.yaw_threshold):
             return self.Submerged()
+        return None
+
+    def handle_once_timedout(self) -> TimedOut:
+        return self.TimedOut()
+
+
+class AlignToYaw(TimedState):
+    target_yaw = 0.0
+    yaw_threshold = 2.0
+
+    class Aligned(Outcome):
+        pass
+
+    class TimedOut(Outcome):
+        pass
+
+    def handle_if_not_timedout(self) -> Union[Aligned, None]:
+        self.io_node.set_target_pose_yaw(self.target_yaw)
+
+        if self.io_node.is_yaw_within_threshold(self.yaw_threshold):
+            return self.Aligned()
         return None
 
     def handle_once_timedout(self) -> TimedOut:

--- a/mrobosub_planning/mrobosub_planning/common_states.py
+++ b/mrobosub_planning/mrobosub_planning/common_states.py
@@ -61,6 +61,48 @@ class AlignToYaw(TimedState):
     def handle_once_timedout(self) -> TimedOut:
         return self.TimedOut()
 
+class AlignToYaw(TimedState):
+    target_yaw = 0.0
+    yaw_threshold = 2.0
+
+    class Aligned(Outcome):
+        pass
+
+    class TimedOut(Outcome):
+        pass
+
+    def handle_if_not_timedout(self) -> Union[Aligned, None]:
+        self.io_node.set_target_pose_yaw(self.target_yaw)
+
+        if self.io_node.is_yaw_within_threshold(self.yaw_threshold):
+            return self.Aligned()
+        return None
+
+    def handle_once_timedout(self) -> TimedOut:
+        return self.TimedOut()
+
+class Surge(TimedState):
+    class Surged(Outcome):
+        pass
+
+    class TimedOut(Outcome):
+        pass
+    distance = 10
+    velocity = 2
+    timeout: float = distance/velocity
+
+
+    def handle_if_not_timedout(self) -> Union[Surged, None]:
+        self.timeout = self.distance/self.velocity
+        self.io_node.set_target_twist_surge(self.velocity);
+
+        #if self.io_node.calculate_distance_to_target():
+        #    return self.Submerged()
+        return None
+
+    def handle_once_timedout(self) -> Surged:
+        return self.Surged();
+
 
 class Stop(State):
     class Surfaced(Outcome):
@@ -79,6 +121,7 @@ class Stop(State):
 
 
 Surface = Stop
+
 class Surge(TimedState):
     class Surged(Outcome):
         pass

--- a/mrobosub_planning/mrobosub_planning/common_states.py
+++ b/mrobosub_planning/mrobosub_planning/common_states.py
@@ -79,3 +79,25 @@ class Stop(State):
 
 
 Surface = Stop
+class Surge(TimedState):
+    class Surged(Outcome):
+        pass
+
+    class TimedOut(Outcome):
+        pass
+    distance = 10
+    velocity = 2
+    timeout: float = distance/velocity
+
+
+    def handle_if_not_timedout(self) -> Union[Surged, None]:
+        self.timeout = self.distance/self.velocity
+        self.io_node.set_target_twist_surge(self.velocity);
+
+        #if self.io_node.calculate_distance_to_target():
+        #    return self.Submerged()
+        return None
+
+    def handle_once_timedout(self) -> Surged:
+        return self.Surged();
+     

--- a/mrobosub_planning/mrobosub_planning/standard_run.py
+++ b/mrobosub_planning/mrobosub_planning/standard_run.py
@@ -1,12 +1,47 @@
-from mrobosub_planning.common_states import Start, Submerge, Surface, Stop
+#!/usr/bin/env python
+from mrobosub_planning.common_states import Start, Submerge, Surface, Stop, Surge
 from mrobosub_planning.umrsm import TransitionMap
+
+def make_move_forward():
+    class SurgeExtender(Surge): pass 
+    class AlignExtender(AlignToYaw): pass
+    return SurgeExtender, AlignExtender
+
+Surge1, Align1 = make_move_forward()
+Surge2, Align2 = make_move_forward()
+Surge3, Align3 = make_move_forward()
+Surge4, Align4 = make_move_forward()
+Surge5, Align5 = make_move_forward()
+Surge6, _ = make_move_forward()
 
 
 transitions: TransitionMap = {
     Start.Complete: Submerge.with_params(target_heave=1.),
 
-    Submerge.Submerged: Surface,
+    Submerge.Submerged: Surge1.with_params(distance=20.),  # object distance
     Submerge.TimedOut: Surface,
+
+    Surge1.Surged: Align1.with_params(yaw=45.),
+    Align1.Aligned: Surge2.with_params(distance=10.)
+    Align1.TimedOut: Surface,
+
+    Surge2.Surged: Align2.with_params(yaw=315.),
+    Align2.Aligned: Surge3.with_params(distance=10.)
+    Align2.TimedOut: Surface,
+
+    Surge3.Surged: Align3.with_params(yaw=225.),
+    Align3.Aligned: Surge4.with_params(distance=10.)
+    Align3.TimedOut: Surface,
+
+    Surge4.Surged: Align4.with_params(yaw=135.),
+    Align4.Aligned: Surge5.with_params(distance=10.)
+    Align4.TimedOut: Surface,
+
+    Surge5.Surged: Align5.with_params(yaw=180.),
+    Align5.Aligned: Surge6.with_params(distance=20.)
+    Align5.TimedOut: Surface,
+
+    Surge6.Surged: Surface,
 
     Surface.Surfaced: Stop
 }


### PR DESCRIPTION
Add states for moving forward and aligning to a yaw angle. Currently includes a testing transition map that will approach an object and navigate in a square around it, before returning to the starting position. Navigation is open loop so likely will not work well in practice.