### PR TITLE
Fixes the way that the IMU node is launched in imu_launch.xml

### DIFF
--- a/mrobosub_hal_imu/launch/imu_launch.xml
+++ b/mrobosub_hal_imu/launch/imu_launch.xml
@@ -1,3 +1,5 @@
 <launch>
-    <node pkg="mrobosub_hal_imu" exec="imu_node" name="imu"/>
+    <arg name="imu_port" default="/dev/ttyACM1" />
+    <node pkg="mrobosub_hal_imu" exec="imu_node" name="imu"
+          args="$(var imu_port)"/>
 </launch>

--- a/mrobosub_hal_imu/src/imu_node.cpp
+++ b/mrobosub_hal_imu/src/imu_node.cpp
@@ -48,14 +48,7 @@ int main(int argc, char **argv)
 
     // By default, ROS2 will pass in some ROS-specific arguments through the command line as well.
     // We only want to read our specific argument.
-
     std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
-
-    std::cout << "The size of non_ros_args was " << non_ros_args.size() << "\n";    
-    for (const auto& arg : non_ros_args) {
-        std::cout << arg << "\n";
-    }
-
     if (non_ros_args.size() != 2)
     {
         std::cout << "Usage: " << non_ros_args[0] << " <port>\n";
@@ -70,7 +63,7 @@ int main(int argc, char **argv)
     }
 
     InertialSense is;
-    is.Open(argv[1]);
+    is.Open(non_ros_args[1]);
 
     auto pimu_registered = is.BroadcastBinaryData(
         DID_PIMU, 

--- a/mrobosub_hal_imu/src/imu_node.cpp
+++ b/mrobosub_hal_imu/src/imu_node.cpp
@@ -1,5 +1,7 @@
 #include <cstdio>
 #include <iostream>
+#include <vector>
+#include <string>
 #include "../inertial-sense-sdk/src/InertialSense.h"
 #include "../inertial-sense-sdk/src/data_sets.h"
 
@@ -44,9 +46,19 @@ int main(int argc, char **argv)
 
     TimeManager timeManager(node);
 
-    if (argc != 2)
+    // By default, ROS2 will pass in some ROS-specific arguments through the command line as well.
+    // We only want to read our specific argument.
+
+    std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
+
+    std::cout << "The size of non_ros_args was " << non_ros_args.size() << "\n";    
+    for (const auto& arg : non_ros_args) {
+        std::cout << arg << "\n";
+    }
+
+    if (non_ros_args.size() != 2)
     {
-        std::printf("Usage: %s <port>\n", argv[0]);
+        std::cout << "Usage: " << non_ros_args[0] << " <port>\n";
         return 1;
     }
 
@@ -60,38 +72,50 @@ int main(int argc, char **argv)
     InertialSense is;
     is.Open(argv[1]);
 
-    auto pimu_registered = is.BroadcastBinaryData(DID_PIMU, 1, [&](InertialSense *is, p_data_t *_data, int pHandle)
-                                                  {
-        const auto data = reinterpret_cast<const pimu_t*>(_data->ptr);
+    auto pimu_registered = is.BroadcastBinaryData(
+        DID_PIMU, 
+        1, 
+        [&](InertialSense *is, p_data_t *_data, int pHandle)
+        {
+            const auto data = reinterpret_cast<const pimu_t*>(_data->ptr);
 
-        mrobosub_msgs::msg::ImuPIMU msg;
-        const auto div = 1.0f/data->dt;
+            mrobosub_msgs::msg::ImuPIMU msg;
+            const auto div = 1.0f/data->dt;
 
-        msg.header.stamp = timeManager.ros_time_from_start_time(data->time);
-        msg.dt = data->dt;
-        msg.angular_velocity.x = data->theta[0] * div;
-        msg.angular_velocity.y = data->theta[1] * div;
-        msg.angular_velocity.z = data->theta[2] * div;
-        msg.linear_acceleration.x = data->vel[0] * div;
-        msg.linear_acceleration.y = data->vel[1] * div;
-        msg.linear_acceleration.z = data->vel[2] * div;
-        pub_pimu->publish(msg); });
+            msg.header.stamp = timeManager.ros_time_from_start_time(data->time);
+            msg.dt = data->dt;
+            msg.angular_velocity.x = data->theta[0] * div;
+            msg.angular_velocity.y = data->theta[1] * div;
+            msg.angular_velocity.z = data->theta[2] * div;
+            msg.linear_acceleration.x = data->vel[0] * div;
+            msg.linear_acceleration.y = data->vel[1] * div;
+            msg.linear_acceleration.z = data->vel[2] * div;
+            pub_pimu->publish(msg); 
+        }
+    );
+
     if (!pimu_registered)
     {
         return 1;
     }
 
-    auto ins_registered = is.BroadcastBinaryData(DID_INS_1, 1, [&](InertialSense *is, p_data_t *_data, int pHandle)
-                                                 {
-        const auto data = reinterpret_cast<const ins_1_t*>(_data->ptr); 
+    auto ins_registered = is.BroadcastBinaryData(
+        DID_INS_1, 
+        1, 
+        [&](InertialSense *is, p_data_t *_data, int pHandle)
+        {
+            const auto data = reinterpret_cast<const ins_1_t*>(_data->ptr); 
 
-        mrobosub_msgs::msg::ImuINS msg;
+            mrobosub_msgs::msg::ImuINS msg;
 
-        msg.header.stamp = timeManager.ros_time_from_start_time(data->timeOfWeek);
-        msg.theta.x = data->theta[0];
-        msg.theta.y = data->theta[1];
-        msg.theta.z = data->theta[2];
-        pub_ins->publish(msg); });
+            msg.header.stamp = timeManager.ros_time_from_start_time(data->timeOfWeek);
+            msg.theta.x = data->theta[0];
+            msg.theta.y = data->theta[1];
+            msg.theta.z = data->theta[2];
+            pub_ins->publish(msg); 
+        }
+    );
+
     if (!ins_registered)
     {
         return 1;


### PR DESCRIPTION
The way we had it previously, and the way I have changed it to, is to accept the port of the IMU via command line argument (`<arg ..>` in the launch file) as opposed to a parameter. I could really go either way here, but for the time being, the IMU node can be launched with the following command:
```sh
ros2 launch mrobosub_hal_imu imu_launch.xml <port:=/dev/tty...>
```
Also, I added a default which happens to match the USB port the IMU is currently plugged into. This is subject to change but can be easily found out by `ls`ing the `/dev` directory, looking at which `/dev/ttyACM#` devices are plugged in, then removing the USB and seeing which device disappears. (Make sure to replug in the device before trying to launch the node (-: ).

You could also `udevadm` each of the `/dev/ttyACM#`, but the IMU comes up as an arbitrary STM electronic device so it could be confusing to identify at first.