### PR TITLE
Rename mock_arduino_tester to arduino

### DIFF
--- a/mrobosub_hal/mrobosub_hal/arduino.py
+++ b/mrobosub_hal/mrobosub_hal/arduino.py
@@ -10,9 +10,9 @@ FREQUENCY = 60 # times per second
 BAUD_RATE = 9600
 CONNECTION_NAME = "/dev/ttyACM0"
 
-class MockArduino(Node):
+class Arduino(Node):
     def __init__(self):
-        super().__init__("mock_arduino")
+        super().__init__("arduino")
 
         self.charm_pub = self.create_publisher(
             Bool, "/buttons/charm", qos_profile=1
@@ -69,7 +69,7 @@ class MockArduino(Node):
 
 def main():
     rclpy.init()
-    node = MockArduino()
+    node = Arduino()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/mrobosub_hal/setup.py
+++ b/mrobosub_hal/setup.py
@@ -28,6 +28,7 @@ setup(
             "dvl_publisher = mrobosub_hal.dvl_publisher:main",
             "botcam = mrobosub_hal.botcam:main",
             "zed = mrobosub_hal.zed:main",
+            "arduino = mrobosub_hal.arduino:main"
         ],
     },
 )


### PR DESCRIPTION
This is the actual code for the arduino node, so there is no use in calling it mock_arduino_tester any longer.